### PR TITLE
n80100 changed to n81100 for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ it:
 The function **sd** finds the standard deviation.  
 
 Note that we used R's *assignment operator* here to copy ("assign")
-those particular  **Nile** elements to **n80100**.  (In most situations,
+those particular  **Nile** elements to **n81100**.  (In most situations,
 you can use "=" instead of "<-", but why worry about what the exceptions
 might be?  They are arcane, so it's easier just to always use "<-".
 And though "keyboard shortcuts" for this are possible, again let's just
@@ -379,21 +379,21 @@ made a copy of those elements.  The original vector **Nile** remains
 intact.
 
 > <span style="color:red">Tip:</span>
-> We can pretty much choose any name we want; "n80100" just was chosen
+> We can pretty much choose any name we want; "n81100" just was chosen
 > to easily remember this new vector's provenance.  (But names can't
 > include spaces, and must start with a letter.)
 
-Note that **n80100** now is a 21-element vector.  Its first element is
-now element 80 of **Nile**:
+Note that **n81100** now is a 20-element vector.  Its first element is
+now element 81 of **Nile**:
 
 ``` r
-> n80100[1]
-[1] 890
-> Nile[80]
-[1] 890
+> n81100[1]
+[1] 744
+> Nile[81]
+[1] 744
 ```
 
-Keep in mind that although **Nile** and **n80100** now have identical
+Keep in mind that although **Nile** and **n81100** now have identical
 contents, they are *separate* vectors; if one changes, the other will
 not.
 


### PR DESCRIPTION
The assignment operator example copies the 81st to 100th elements of the Nile dataset to the variable `n81100`, but the subsequent explanation refers to it as `n80100`. I changed the subsequent explanation to use `n81100` instead of `n80100` (and made other appropriate changes) to stay consistent with the example.